### PR TITLE
Unify procedure call node with method call node for n-arity validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Right now only a handful of basic types is supported:
     - `FindSet()[: Boolean]`
     - `Next([Steps: Number]): Number`
     - `SetRange(Field: Identifier, [FromValue: FieldType, [ToValue: FieldType]])`
-    - `SetFilter(Field: Identifier, Filter: Text)`
+    - `SetFilter(Field: Identifier, Filter: Tex, [Substitution: Any, ...])` (up to 10 substitutions)
     - `Insert([RunTrigger: Boolean])[: Boolean]`
     - `Modify([RunTrigger: Boolean])[: Boolean]`
     - `Delete([RunTrigger: Boolean])[: Boolean]`
@@ -100,12 +100,13 @@ Right now only a handful of basic types is supported:
 
 #### Built-in functions
 
-- `Message(Text: Text)`
-- `Error(Text: Text)`
-- `WriteLine(Text: Text)`
+- `Message(Text: Text, [Substitution: Any, ...])` (up to 10 substitutions)
+- `Error(Text: Text, [Substitution: Any, ...])` (up to 10 substitutions)
+- `WriteLine(Text: Text, [Substitution: Any, ...])` (up to 10 substitutions)
 - `Abs(Number: Number): Number`
 - `Power(Number: Number, Power: Number): Number`
-- `Format(Input: Any): Text`
+- `Format(Input: Any, [Length: Number, [FormatNumber: Number]]): Text`
+- `Format(Input: Any, [Length: Number, [FormatString: Text]]): Text`
 
 ### Planned
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ end;
 
 Right now only a handful of basic types is supported:
 
-- `number` (for both integers and decimals)
+- `number` (for both integers and decimals - this may cause problems when formatting numbers)
 - `boolean`
 - `text`
   - methods

--- a/app/src/Parser/Functions/BuiltIns/AbsFunction.Codeunit.al
+++ b/app/src/Parser/Functions/BuiltIns/AbsFunction.Codeunit.al
@@ -14,14 +14,24 @@ codeunit 69200 "Abs Function FS" implements "Function FS"
         exit(SymbolTable.NumericSymbol());
     end;
 
-    procedure GetArity(): Integer
-    begin
-        exit(1);
-    end;
-
-    procedure GetParameters(var ParameterSymbol: Record "Symbol FS")
+    procedure ValidateCallArguments
+    (
+        Runtime: Codeunit "Runtime FS";
+        SymbolTable: Codeunit "Symbol Table FS";
+        Arguments: Codeunit "Node Linked List FS"
+    )
+    var
+        ParameterSymbol: Record "Symbol FS";
     begin
         ParameterSymbol.InsertNumber('Number', 1);
+
+        Runtime.ValidateMethodCallArguments(
+            Runtime,
+            SymbolTable,
+            GetName(),
+            Arguments,
+            ParameterSymbol
+        );
     end;
 
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"

--- a/app/src/Parser/Functions/BuiltIns/ErrorFunction.Codeunit.al
+++ b/app/src/Parser/Functions/BuiltIns/ErrorFunction.Codeunit.al
@@ -14,16 +14,24 @@ codeunit 69203 "Error Function FS" implements "Function FS"
         exit(SymbolTable.VoidSymbol());
     end;
 
-    procedure GetArity(): Integer
-    begin
-        exit(1);
-    end;
-
-    // TODO this will make things difficult for functions with
-    // >>>> variable parity - message, error, setrange...
-    procedure GetParameters(var ParameterSymbol: Record "Symbol FS")
+    procedure ValidateCallArguments
+    (
+        Runtime: Codeunit "Runtime FS";
+        SymbolTable: Codeunit "Symbol Table FS";
+        Arguments: Codeunit "Node Linked List FS"
+    )
+    var
+        ParameterSymbol: Record "Symbol FS";
     begin
         ParameterSymbol.InsertText('Text', 1);
+
+        Runtime.ValidateMethodCallArguments(
+            Runtime,
+            SymbolTable,
+            GetName(),
+            Arguments,
+            ParameterSymbol
+        );
     end;
 
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"

--- a/app/src/Parser/Functions/BuiltIns/FormatFunction.Codeunit.al
+++ b/app/src/Parser/Functions/BuiltIns/FormatFunction.Codeunit.al
@@ -21,30 +21,98 @@ codeunit 69205 "Format Function FS" implements "Function FS"
         Arguments: Codeunit "Node Linked List FS"
     )
     var
-        ParameterSymbol: Record "Symbol FS";
+        ParameterSymbol, Symbol : Record "Symbol FS";
+        ArgumentNode: Codeunit "Node Linked List Node FS";
     begin
-        ParameterSymbol.InsertAny('Any', 1);
+        if not (Arguments.GetCount() in [1 .. 3]) then
+            Error('Parameter count missmatch when calling method %1.', GetName());
 
-        Runtime.ValidateMethodCallArguments(
+        ArgumentNode := Arguments.First();
+        ParameterSymbol.InsertAny('Any', 1);
+        Runtime.TestParameterVsArgument(
             Runtime,
             SymbolTable,
             GetName(),
-            Arguments,
-            ParameterSymbol
+            ParameterSymbol,
+            ArgumentNode
         );
+
+        if not ArgumentNode.HasNext() then
+            exit;
+
+        ArgumentNode := ArgumentNode.Next();
+        ParameterSymbol.InsertNumber('Length', 2);
+        Runtime.TestParameterVsArgument(
+            Runtime,
+            SymbolTable,
+            GetName(),
+            ParameterSymbol,
+            ArgumentNode
+        );
+
+        if not ArgumentNode.HasNext() then
+            exit;
+
+        ArgumentNode := ArgumentNode.Next();
+        Symbol := ArgumentNode.Value().ValidateSemantics(Runtime, SymbolTable);
+        if not (Symbol.Type in [Symbol.Type::Text, Symbol.Type::Number]) then
+            Error(
+                'Parameter call missmatch when calling method %1.\\Expected %2 or %3, got %4.',
+                GetName(),
+                Symbol.Type::Text,
+                Symbol.Type::Number,
+                Symbol.TypeToText()
+            );
     end;
 
+    // TODO format has two issues
+    // >>>> 1. unexpected results when formatting "integers"
+    // >>>> 2. there might be a problem passing everything in as a variant? (Standard format number 4 does not exist for the type 'Variant')
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"
     var
         Node: Codeunit "Value Linked List Node FS";
         TextValue: Codeunit "Text Value FS";
-        Text: Text;
+        Input, Length : Interface "Value FS";
+        FormatVariant: Variant;
+        Text, FormatString : Text;
+        FormatNumber: Integer;
     begin
         Node := ValueLinkedList.First();
 
-        Text := Format(Node.Value().GetValue());
-        TextValue.SetValue(Text);
+        Input := Node.Value();
+        if not Node.HasNext() then begin
+            Text := Format(Input.GetValue());
+            TextValue.SetValue(Text);
+            exit(TextValue);
+        end;
 
+        Node := Node.Next();
+        Length := Node.Value();
+        if not Node.HasNext() then begin
+            Text := Format(Input.GetValue(), Length.GetValue());
+            TextValue.SetValue(Text);
+            exit(TextValue);
+        end;
+
+        Node := Node.Next();
+        FormatVariant := Node.Value().GetValue();
+        case true of
+            FormatVariant.IsText():
+                begin
+                    FormatString := FormatVariant;
+                    Text := Format(Input.GetValue(), Length.GetValue(), FormatString);
+                end;
+            FormatVariant.IsInteger(),
+            FormatVariant.IsDecimal():
+                begin
+                    FormatNumber := FormatVariant;
+                    Text := Format(Input.GetValue(), Length.GetValue(), FormatNumber);
+                end;
+            else
+                Error('Unimplementd: Unexpcted format.');
+        end;
+
+        TextValue.SetValue(Text);
         exit(TextValue);
     end;
 }

--- a/app/src/Parser/Functions/BuiltIns/FormatFunction.Codeunit.al
+++ b/app/src/Parser/Functions/BuiltIns/FormatFunction.Codeunit.al
@@ -65,9 +65,7 @@ codeunit 69205 "Format Function FS" implements "Function FS"
             );
     end;
 
-    // TODO format has two issues
-    // >>>> 1. unexpected results when formatting "integers"
-    // >>>> 2. there might be a problem passing everything in as a variant? (Standard format number 4 does not exist for the type 'Variant')
+    // TODO formatting numbers has issues - unexpected results when formatting "integers"
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"
     var
         Node: Codeunit "Value Linked List Node FS";
@@ -81,7 +79,7 @@ codeunit 69205 "Format Function FS" implements "Function FS"
 
         Input := Node.Value();
         if not Node.HasNext() then begin
-            Text := Format(Input.GetValue());
+            Text := Input.Format();
             TextValue.SetValue(Text);
             exit(TextValue);
         end;
@@ -89,7 +87,7 @@ codeunit 69205 "Format Function FS" implements "Function FS"
         Node := Node.Next();
         Length := Node.Value();
         if not Node.HasNext() then begin
-            Text := Format(Input.GetValue(), Length.GetValue());
+            Text := Input.Format(Length.GetValue());
             TextValue.SetValue(Text);
             exit(TextValue);
         end;
@@ -100,16 +98,16 @@ codeunit 69205 "Format Function FS" implements "Function FS"
             FormatVariant.IsText():
                 begin
                     FormatString := FormatVariant;
-                    Text := Format(Input.GetValue(), Length.GetValue(), FormatString);
+                    Text := Input.Format(Length.GetValue(), FormatString);
                 end;
             FormatVariant.IsInteger(),
             FormatVariant.IsDecimal():
                 begin
                     FormatNumber := FormatVariant;
-                    Text := Format(Input.GetValue(), Length.GetValue(), FormatNumber);
+                    Text := Input.Format(Length.GetValue(), FormatNumber);
                 end;
             else
-                Error('Unimplementd: Unexpcted format.');
+                Error('Unimplemented: Unexpected format.');
         end;
 
         TextValue.SetValue(Text);

--- a/app/src/Parser/Functions/BuiltIns/FormatFunction.Codeunit.al
+++ b/app/src/Parser/Functions/BuiltIns/FormatFunction.Codeunit.al
@@ -14,19 +14,24 @@ codeunit 69205 "Format Function FS" implements "Function FS"
         exit(SymbolTable.TextSymbol());
     end;
 
-    procedure GetArity(): Integer // TODO return a record with min and max?
-    begin
-        exit(1);
-    end;
-
-    // TODO this will make things difficult for functions with
-    // >>>> variable parity - message, error, setrange...
-    procedure GetParameters(var ParameterSymbol: Record "Symbol FS")
+    procedure ValidateCallArguments
+    (
+        Runtime: Codeunit "Runtime FS";
+        SymbolTable: Codeunit "Symbol Table FS";
+        Arguments: Codeunit "Node Linked List FS"
+    )
+    var
+        ParameterSymbol: Record "Symbol FS";
     begin
         ParameterSymbol.InsertAny('Any', 1);
 
-        // TODO allow to create multiple sets here?
-        // >>>> call match from here? arity as parameter?
+        Runtime.ValidateMethodCallArguments(
+            Runtime,
+            SymbolTable,
+            GetName(),
+            Arguments,
+            ParameterSymbol
+        );
     end;
 
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"

--- a/app/src/Parser/Functions/BuiltIns/MessageFunction.Codeunit.al
+++ b/app/src/Parser/Functions/BuiltIns/MessageFunction.Codeunit.al
@@ -21,17 +21,35 @@ codeunit 69202 "Message Function FS" implements "Function FS"
         Arguments: Codeunit "Node Linked List FS"
     )
     var
-        ParameterSymbol: Record "Symbol FS";
+        ParameterSymbol, Symbol : Record "Symbol FS";
+        ArgumentNode: Codeunit "Node Linked List Node FS";
     begin
-        ParameterSymbol.InsertText('Text', 1);
+        if not (Arguments.GetCount() in [1 .. Runtime.MaxAllowedSubstitutions() + 1]) then
+            Error('Parameter count missmatch when calling method %1.', GetName());
 
-        Runtime.ValidateMethodCallArguments(
-            Runtime,
-            SymbolTable,
-            GetName(),
-            Arguments,
-            ParameterSymbol
-        );
+        // first argument must be the text template
+        ArgumentNode := Arguments.First();
+        Symbol := ArgumentNode.Value().ValidateSemantics(Runtime, SymbolTable);
+        if Symbol.Type <> Symbol.Type::Text then
+            Error(
+                'Parameter call missmatch when calling method %1.\\Expected %2, got %3.',
+                GetName(),
+                ParameterSymbol.TypeToText(),
+                Symbol.TypeToText()
+            );
+
+        // all other arguments can be anything
+        ParameterSymbol.InsertAny('Any', 1);
+        while ArgumentNode.Next(ArgumentNode) do begin
+            Symbol := ArgumentNode.Value().ValidateSemantics(Runtime, SymbolTable);
+            if not Runtime.TypesMatch(ParameterSymbol, Symbol) then
+                Error(
+                    'Parameter call missmatch when calling method %1.\\Expected %2, got %3.',
+                    GetName(),
+                    ParameterSymbol.TypeToText(),
+                    Symbol.TypeToText()
+                );
+        end;
     end;
 
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"
@@ -43,7 +61,7 @@ codeunit 69202 "Message Function FS" implements "Function FS"
         Node := ValueLinkedList.First();
         Text := Node.Value().GetValue();
 
-        Message(Text);
+        Message(Runtime.SubstituteText(Text, Node, ValueLinkedList.GetCount() - 1));
 
         exit(VoidValue);
     end;

--- a/app/src/Parser/Functions/BuiltIns/MessageFunction.Codeunit.al
+++ b/app/src/Parser/Functions/BuiltIns/MessageFunction.Codeunit.al
@@ -14,16 +14,24 @@ codeunit 69202 "Message Function FS" implements "Function FS"
         exit(SymbolTable.VoidSymbol());
     end;
 
-    procedure GetArity(): Integer
-    begin
-        exit(1);
-    end;
-
-    // TODO this will make things difficult for functions with
-    // >>>> variable parity - message, error, setrange...
-    procedure GetParameters(var ParameterSymbol: Record "Symbol FS")
+    procedure ValidateCallArguments
+    (
+        Runtime: Codeunit "Runtime FS";
+        SymbolTable: Codeunit "Symbol Table FS";
+        Arguments: Codeunit "Node Linked List FS"
+    )
+    var
+        ParameterSymbol: Record "Symbol FS";
     begin
         ParameterSymbol.InsertText('Text', 1);
+
+        Runtime.ValidateMethodCallArguments(
+            Runtime,
+            SymbolTable,
+            GetName(),
+            Arguments,
+            ParameterSymbol
+        );
     end;
 
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"

--- a/app/src/Parser/Functions/BuiltIns/PowerFunction.Codeunit.al
+++ b/app/src/Parser/Functions/BuiltIns/PowerFunction.Codeunit.al
@@ -14,17 +14,25 @@ codeunit 69201 "Power Function FS" implements "Function FS"
         exit(SymbolTable.NumericSymbol());
     end;
 
-    procedure GetArity(): Integer
-    begin
-        exit(2);
-    end;
-
-    // TODO this will make things difficult for functions with
-    // >>>> variable parity - message, error, setrange...
-    procedure GetParameters(var ParameterSymbol: Record "Symbol FS")
+    procedure ValidateCallArguments
+    (
+        Runtime: Codeunit "Runtime FS";
+        SymbolTable: Codeunit "Symbol Table FS";
+        Arguments: Codeunit "Node Linked List FS"
+    )
+    var
+        ParameterSymbol: Record "Symbol FS";
     begin
         ParameterSymbol.InsertNumber('Number', 1);
         ParameterSymbol.InsertNumber('Power', 2);
+
+        Runtime.ValidateMethodCallArguments(
+            Runtime,
+            SymbolTable,
+            GetName(),
+            Arguments,
+            ParameterSymbol
+        );
     end;
 
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"

--- a/app/src/Parser/Functions/BuiltIns/WriteLineFunction.Codeunit.al
+++ b/app/src/Parser/Functions/BuiltIns/WriteLineFunction.Codeunit.al
@@ -14,16 +14,24 @@ codeunit 69204 "Write Line Function FS" implements "Function FS"
         exit(SymbolTable.VoidSymbol());
     end;
 
-    procedure GetArity(): Integer
-    begin
-        exit(1);
-    end;
-
-    // TODO this will make things difficult for functions with
-    // >>>> variable parity - message, error, setrange...
-    procedure GetParameters(var ParameterSymbol: Record "Symbol FS")
+    procedure ValidateCallArguments
+    (
+        Runtime: Codeunit "Runtime FS";
+        SymbolTable: Codeunit "Symbol Table FS";
+        Arguments: Codeunit "Node Linked List FS"
+    )
+    var
+        ParameterSymbol: Record "Symbol FS";
     begin
         ParameterSymbol.InsertText('Text', 1);
+
+        Runtime.ValidateMethodCallArguments(
+            Runtime,
+            SymbolTable,
+            GetName(),
+            Arguments,
+            ParameterSymbol
+        );
     end;
 
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"

--- a/app/src/Parser/Functions/BuiltIns/WriteLineFunction.Codeunit.al
+++ b/app/src/Parser/Functions/BuiltIns/WriteLineFunction.Codeunit.al
@@ -21,17 +21,35 @@ codeunit 69204 "Write Line Function FS" implements "Function FS"
         Arguments: Codeunit "Node Linked List FS"
     )
     var
-        ParameterSymbol: Record "Symbol FS";
+        ParameterSymbol, Symbol : Record "Symbol FS";
+        ArgumentNode: Codeunit "Node Linked List Node FS";
     begin
-        ParameterSymbol.InsertText('Text', 1);
+        if not (Arguments.GetCount() in [1 .. Runtime.MaxAllowedSubstitutions() + 1]) then
+            Error('Parameter count missmatch when calling method %1.', GetName());
 
-        Runtime.ValidateMethodCallArguments(
-            Runtime,
-            SymbolTable,
-            GetName(),
-            Arguments,
-            ParameterSymbol
-        );
+        // first argument must be the text template
+        ArgumentNode := Arguments.First();
+        Symbol := ArgumentNode.Value().ValidateSemantics(Runtime, SymbolTable);
+        if Symbol.Type <> Symbol.Type::Text then
+            Error(
+                'Parameter call missmatch when calling method %1.\\Expected %2, got %3.',
+                GetName(),
+                ParameterSymbol.TypeToText(),
+                Symbol.TypeToText()
+            );
+
+        // all other arguments can be anything
+        ParameterSymbol.InsertAny('Any', 1);
+        while ArgumentNode.Next(ArgumentNode) do begin
+            Symbol := ArgumentNode.Value().ValidateSemantics(Runtime, SymbolTable);
+            if not Runtime.TypesMatch(ParameterSymbol, Symbol) then
+                Error(
+                    'Parameter call missmatch when calling method %1.\\Expected %2, got %3.',
+                    GetName(),
+                    ParameterSymbol.TypeToText(),
+                    Symbol.TypeToText()
+                );
+        end;
     end;
 
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"
@@ -43,7 +61,7 @@ codeunit 69204 "Write Line Function FS" implements "Function FS"
         Node := ValueLinkedList.First();
         Text := Node.Value().GetValue();
 
-        Runtime.WriteLine(Text);
+        Runtime.WriteLine(Runtime.SubstituteText(Text, Node, ValueLinkedList.GetCount() - 1));
 
         exit(VoidValue);
     end;

--- a/app/src/Parser/Functions/Function.Interface.al
+++ b/app/src/Parser/Functions/Function.Interface.al
@@ -2,10 +2,15 @@ interface "Function FS"
 {
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"
 
+    procedure ValidateCallArguments
+    (
+        Runtime: Codeunit "Runtime FS";
+        SymbolTable: Codeunit "Symbol Table FS";
+        Arguments: Codeunit "Node Linked List FS"
+    );
+
     procedure GetName(): Text[120]
     procedure GetReturnType(): Record "Symbol FS"
-    procedure GetArity(): Integer
-    procedure GetParameters(var ParameterSymbol: Record "Symbol FS")
 
     // TODO procedure SetTopLevel() - both functions and methods? useful in methods like get
 }

--- a/app/src/Parser/Functions/UserFunction.Codeunit.al
+++ b/app/src/Parser/Functions/UserFunction.Codeunit.al
@@ -27,14 +27,24 @@ codeunit 69025 "User Function FS" implements "Function FS"
         exit(SymbolTable.GetReturnType());
     end;
 
-    procedure GetArity(): Integer
-    begin
-        exit(SymbolTable.GetParameterCount());
-    end;
-
-    procedure GetParameters(var ParameterSymbol: Record "Symbol FS")
+    procedure ValidateCallArguments
+    (
+        Runtime: Codeunit "Runtime FS";
+        ContextSymbolTable: Codeunit "Symbol Table FS";
+        Arguments: Codeunit "Node Linked List FS"
+    )
+    var
+        ParameterSymbol: Record "Symbol FS";
     begin
         SymbolTable.GetParameters(ParameterSymbol);
+
+        Runtime.ValidateMethodCallArguments(
+            Runtime,
+            ContextSymbolTable,
+            GetName(),
+            Arguments,
+            ParameterSymbol
+        );
     end;
 
     procedure Evaluate(Runtime: Codeunit "Runtime FS"; ValueLinkedList: Codeunit "Value Linked List FS"): Interface "Value FS"

--- a/app/src/Parser/Methods/Record/RecordSetFilter.Codeunit.al
+++ b/app/src/Parser/Methods/Record/RecordSetFilter.Codeunit.al
@@ -26,15 +26,12 @@ codeunit 69323 "Record SetFilter FS" implements "Method FS"
         ArgumentNode := Arguments.First().Next(); // skip first parameter
         ValueLinkedList := Runtime.EvaluateArguments(Runtime, ArgumentNode);
         ValueNode := ValueLinkedList.First();
-        // TODO does not work the same way as AL SetFilter
-        // in AL, if the template string contains * or ? then replacement does not happen?
-        // > Currency.SetFilter(Code, '%1|%2*|%3', 'EUR', 'D', 'XXX');
-        // > EUR and XXX are replaced, but D is not?
-        FieldRef.SetFilter(Runtime.SubstituteText(
+        SetFilter(
+            FieldRef,
             ValueNode.Value().GetValue(),
             ValueNode,
             ValueLinkedList.GetCount() - 1
-        ));
+        );
 
         exit(VoidValue);
     end;
@@ -51,6 +48,49 @@ codeunit 69323 "Record SetFilter FS" implements "Method FS"
         Field.SetRange(FieldName, Name);
         Field.FindFirst();
         exit(Field."No.");
+    end;
+
+    // SetFilter behaves differently from StrSubstNo
+    local procedure SetFilter
+    (
+        FieldRef: FieldRef;
+        Template: Text;
+        Node: Codeunit "Value Linked List Node FS";
+        Length: Integer
+    )
+    begin
+        case Length of
+            0:
+                FieldRef.SetFilter(Template);
+            1:
+                FieldRef.SetFilter(Template, NextNodeValue(Node));
+            2:
+                FieldRef.SetFilter(Template, NextNodeValue(Node), NextNodeValue(Node));
+            3:
+                FieldRef.SetFilter(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node));
+            4:
+                FieldRef.SetFilter(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node));
+            5:
+                FieldRef.SetFilter(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node));
+            6:
+                FieldRef.SetFilter(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node));
+            7:
+                FieldRef.SetFilter(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node));
+            8:
+                FieldRef.SetFilter(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node));
+            9:
+                FieldRef.SetFilter(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node));
+            10:
+                FieldRef.SetFilter(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node));
+            else
+                Error('Unimplemented: Too many arguments for text substitution.');
+        end;
+    end;
+
+    local procedure NextNodeValue(var Node: Codeunit "Value Linked List Node FS"): Variant
+    begin
+        Node := Node.Next();
+        exit(Node.Value().GetValue());
     end;
 
     procedure GetName(): Text[120];

--- a/app/src/Parser/Methods/Record/RecordSetFilter.Codeunit.al
+++ b/app/src/Parser/Methods/Record/RecordSetFilter.Codeunit.al
@@ -93,6 +93,11 @@ codeunit 69323 "Record SetFilter FS" implements "Method FS"
         exit(Node.Value().GetValue());
     end;
 
+    local procedure MaxAllowedSubstitutions(): Integer
+    begin
+        exit(10);
+    end;
+
     procedure GetName(): Text[120];
     begin
         exit('SetFilter');
@@ -115,7 +120,7 @@ codeunit 69323 "Record SetFilter FS" implements "Method FS"
         Symbol, ParameterSymbol : Record "Symbol FS";
         ArgumentNode: Codeunit "Node Linked List Node FS";
     begin
-        if not (Arguments.GetCount() in [2 .. Runtime.MaxAllowedSubstitutions() + 2]) then
+        if not (Arguments.GetCount() in [2 .. MaxAllowedSubstitutions() + 2]) then
             Error('Parameter count missmatch when calling method %1.', GetName());
 
         ArgumentNode := Arguments.First();

--- a/app/src/Parser/Nodes/ProcedureCallNode.Codeunit.al
+++ b/app/src/Parser/Nodes/ProcedureCallNode.Codeunit.al
@@ -2,6 +2,7 @@ codeunit 69023 "Procedure Call Node FS" implements "Node FS"
 {
     var
         Arguments: Codeunit "Node Linked List FS";
+        Function: Interface "Function FS";
         Name: Text[120];
 
     procedure Init
@@ -26,11 +27,8 @@ codeunit 69023 "Procedure Call Node FS" implements "Node FS"
     var
         ArgumentNode: Codeunit "Node Linked List Node FS";
         ArgumentValues: Codeunit "Value Linked List FS";
-        Function: Interface "Function FS";
         Value: Interface "Value FS";
     begin
-        Function := Runtime.LookupFunction(Name);
-
         if Arguments.First(ArgumentNode) then
             repeat
                 Value := ArgumentNode.Value().Evaluate(Runtime);
@@ -41,15 +39,13 @@ codeunit 69023 "Procedure Call Node FS" implements "Node FS"
     end;
 
     procedure ValidateSemantics(Runtime: Codeunit "Runtime FS"; SymbolTable: Codeunit "Symbol Table FS"): Record "Symbol FS";
-    var
-        Function: Interface "Function FS";
     begin
         Function := Runtime.LookupFunction(Name);
 
-        ValidateProcedureCallArguments(
+        Function.ValidateCallArguments(
             Runtime,
             SymbolTable,
-            Function
+            Arguments
         );
 
         exit(Function.GetReturnType());
@@ -66,54 +62,5 @@ codeunit 69023 "Procedure Call Node FS" implements "Node FS"
             Runtime,
             SymbolTable
         ));
-    end;
-
-    // TODO this will make things difficult for functions with
-    // >>>> variable parity - message, error, setrange...
-    local procedure ValidateProcedureCallArguments
-    (
-        Runtime: Codeunit "Runtime FS";
-        SymbolTable: Codeunit "Symbol Table FS";
-        Function: Interface "Function FS"
-    )
-    var
-        ParameterSymbol, Symbol : Record "Symbol FS";
-        ArgumentNode: Codeunit "Node Linked List Node FS";
-    begin
-        if Arguments.GetCount() <> Function.GetArity() then
-            Error('Parameter count missmatch when calling function %1.', Function.GetName());
-
-        Function.GetParameters(ParameterSymbol);
-        ParameterSymbol.SetCurrentKey(Order); // TODO this feels wrong
-        if not ParameterSymbol.FindSet() then
-            exit;
-
-        ArgumentNode := Arguments.First();
-
-        while true do begin
-            Symbol := ArgumentNode.Value().ValidateSemantics(Runtime, SymbolTable);
-            if not TypesMatch(ParameterSymbol, Symbol) then
-                Error(
-                    'Parameter call missmatch when calling function %1.\\Expected %2, got %3.',
-                    Function.GetName(),
-                    ParameterSymbol.TypeToText(),
-                    Symbol.TypeToText()
-                );
-
-            if ParameterSymbol.Next() = 0 then
-                break;
-            ArgumentNode := ArgumentNode.Next();
-        end;
-    end;
-
-    local procedure TypesMatch
-    (
-        ExpectedSymbol: Record "Symbol FS";
-        ActualSymbol: Record "Symbol FS"
-    ): Boolean
-    begin
-        if ExpectedSymbol.Type = ExpectedSymbol.Type::Any then
-            exit(ActualSymbol.Type <> ActualSymbol.Type::Void);
-        exit(ExpectedSymbol.Compare(ActualSymbol));
     end;
 }

--- a/app/src/Parser/Runtime.Codeunit.al
+++ b/app/src/Parser/Runtime.Codeunit.al
@@ -235,7 +235,6 @@ codeunit 69011 "Runtime FS"
         var ParameterSymbol: Record "Symbol FS"
     )
     var
-        Symbol: Record "Symbol FS";
         ArgumentNode: Codeunit "Node Linked List Node FS";
     begin
         if Arguments.GetCount() <> ParameterSymbol.Count() then
@@ -246,21 +245,42 @@ codeunit 69011 "Runtime FS"
             exit;
 
         ArgumentNode := Arguments.First();
-
         while true do begin
-            Symbol := ArgumentNode.Value().ValidateSemantics(Runtime, SymbolTable);
-            if not TypesMatch(ParameterSymbol, Symbol) then
-                Error(
-                    'Parameter call missmatch when calling method %1.\\Expected %2, got %3.',
-                    Name,
-                    ParameterSymbol.TypeToText(),
-                    Symbol.TypeToText()
-                );
+            TestParameterVsArgument(
+                Runtime,
+                SymbolTable,
+                Name,
+                ParameterSymbol,
+                ArgumentNode
+            );
 
             if ParameterSymbol.Next() = 0 then
                 break;
             ArgumentNode := ArgumentNode.Next();
         end;
+    end;
+
+    procedure TestParameterVsArgument
+    (
+        Runtime: Codeunit "Runtime FS";
+        SymbolTable: Codeunit "Symbol Table FS";
+        Name: Text[120];
+        ExpectedSymbol: Record "Symbol FS";
+        ArgumentNode: Codeunit "Node Linked List Node FS"
+    )
+    var
+        Symbol: Record "Symbol FS";
+    begin
+        Symbol := ArgumentNode.Value().ValidateSemantics(Runtime, SymbolTable);
+        if TypesMatch(ExpectedSymbol, Symbol) then
+            exit;
+
+        Error(
+            'Parameter call missmatch when calling method %1.\\Expected %2, got %3.',
+            Name,
+            ExpectedSymbol.TypeToText(),
+            Symbol.TypeToText()
+        );
     end;
 
     procedure TypesMatch

--- a/app/src/Parser/Runtime.Codeunit.al
+++ b/app/src/Parser/Runtime.Codeunit.al
@@ -294,4 +294,48 @@ codeunit 69011 "Runtime FS"
 
         exit(ArgumentValues);
     end;
+
+    // limited (but simple) solution, 10 substitutions should be more than enough in most situations
+    // can be improved by parsing the template string and handling substitutions? // TODO
+    procedure SubstituteText(Template: Text; Node: Codeunit "Value Linked List Node FS"; Length: Integer): Text
+    begin
+        if Length = 0 then
+            exit(Template);
+
+        case Length of
+            1:
+                exit(StrSubstNo(Template, NextNodeValue(Node)));
+            2:
+                exit(StrSubstNo(Template, NextNodeValue(Node), NextNodeValue(Node)));
+            3:
+                exit(StrSubstNo(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node)));
+            4:
+                exit(StrSubstNo(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node)));
+            5:
+                exit(StrSubstNo(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node)));
+            6:
+                exit(StrSubstNo(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node)));
+            7:
+                exit(StrSubstNo(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node)));
+            8:
+                exit(StrSubstNo(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node)));
+            9:
+                exit(StrSubstNo(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node)));
+            10:
+                exit(StrSubstNo(Template, NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node), NextNodeValue(Node)));
+            else
+                Error('Unimplemented: Too many arguments for text substitution.');
+        end;
+    end;
+
+    procedure MaxAllowedSubstitutions(): Integer
+    begin
+        exit(10);
+    end;
+
+    local procedure NextNodeValue(var Node: Codeunit "Value Linked List Node FS"): Variant
+    begin
+        Node := Node.Next();
+        exit(Node.Value().GetValue());
+    end;
 }

--- a/app/src/Parser/Runtime.Codeunit.al
+++ b/app/src/Parser/Runtime.Codeunit.al
@@ -286,6 +286,17 @@ codeunit 69011 "Runtime FS"
         if not Arguments.First(ArgumentNode) then
             exit(ArgumentValues);
 
+        exit(EvaluateArguments(Runtime, ArgumentNode));
+    end;
+
+    procedure EvaluateArguments
+    (
+        Runtime: Codeunit "Runtime FS";
+        ArgumentNode: Codeunit "Node Linked List Node FS"
+    ): Codeunit "Value Linked List FS"
+    var
+        ArgumentValues: Codeunit "Value Linked List FS";
+    begin
         repeat
             ArgumentValues.Insert(
                 ArgumentNode.Value().Evaluate(Runtime)

--- a/app/src/Parser/Values/BooleanValue.Codeunit.al
+++ b/app/src/Parser/Values/BooleanValue.Codeunit.al
@@ -35,4 +35,24 @@ codeunit 69102 "Boolean Value FS" implements "Value FS"
     begin
         Error('Boolean values do not support property access');
     end;
+
+    procedure Format(): Text;
+    begin
+        exit(System.Format(Value));
+    end;
+
+    procedure Format(Length: Integer): Text;
+    begin
+        exit(System.Format(Value, Length));
+    end;
+
+    procedure Format(Length: Integer; FormatNumber: Integer): Text;
+    begin
+        exit(System.Format(Value, Length, FormatNumber));
+    end;
+
+    procedure Format(Length: Integer; FormatString: Text): Text;
+    begin
+        exit(System.Format(Value, Length, FormatString));
+    end;
 }

--- a/app/src/Parser/Values/NumericValue.Codeunit.al
+++ b/app/src/Parser/Values/NumericValue.Codeunit.al
@@ -35,4 +35,24 @@ codeunit 69101 "Numeric Value FS" implements "Value FS"
     begin
         Error('Numeric values do not support property access');
     end;
+
+    procedure Format(): Text;
+    begin
+        exit(System.Format(Value));
+    end;
+
+    procedure Format(Length: Integer): Text;
+    begin
+        exit(System.Format(Value, Length));
+    end;
+
+    procedure Format(Length: Integer; FormatNumber: Integer): Text;
+    begin
+        exit(System.Format(Value, Length, FormatNumber));
+    end;
+
+    procedure Format(Length: Integer; FormatString: Text): Text;
+    begin
+        exit(System.Format(Value, Length, FormatString));
+    end;
 }

--- a/app/src/Parser/Values/RecordValue.Codeunit.al
+++ b/app/src/Parser/Values/RecordValue.Codeunit.al
@@ -90,4 +90,24 @@ codeunit 69105 "Record Value FS" implements "Value FS"
 
         Value.Field(Field."No.").Value(NewValue.GetValue())
     end;
+
+    procedure Format(): Text;
+    begin
+        exit(System.Format(Value));
+    end;
+
+    procedure Format(Length: Integer): Text;
+    begin
+        exit(System.Format(Value, Length));
+    end;
+
+    procedure Format(Length: Integer; FormatNumber: Integer): Text;
+    begin
+        exit(System.Format(Value, Length, FormatNumber));
+    end;
+
+    procedure Format(Length: Integer; FormatString: Text): Text;
+    begin
+        exit(System.Format(Value, Length, FormatString));
+    end;
 }

--- a/app/src/Parser/Values/ReturnValue.Codeunit.al
+++ b/app/src/Parser/Values/ReturnValue.Codeunit.al
@@ -45,4 +45,24 @@ codeunit 69104 "Return Value FS" implements "Value FS"
     begin
         Error('Return values do not support property access');
     end;
+
+    procedure Format(): Text;
+    begin
+        Error('Return values can not be formatted.');
+    end;
+
+    procedure Format(Length: Integer): Text;
+    begin
+        Error('Return values can not be formatted.');
+    end;
+
+    procedure Format(Length: Integer; FormatNumber: Integer): Text;
+    begin
+        Error('Return values can not be formatted.');
+    end;
+
+    procedure Format(Length: Integer; FormatString: Text): Text;
+    begin
+        Error('Return values can not be formatted.');
+    end;
 }

--- a/app/src/Parser/Values/TextValue.Codeunit.al
+++ b/app/src/Parser/Values/TextValue.Codeunit.al
@@ -35,4 +35,24 @@ codeunit 69103 "Text Value FS" implements "Value FS"
     begin
         Error('Text values do not support property access');
     end;
+
+    procedure Format(): Text;
+    begin
+        exit(System.Format(Value));
+    end;
+
+    procedure Format(Length: Integer): Text;
+    begin
+        exit(System.Format(Value, Length));
+    end;
+
+    procedure Format(Length: Integer; FormatNumber: Integer): Text;
+    begin
+        exit(System.Format(Value, Length, FormatNumber));
+    end;
+
+    procedure Format(Length: Integer; FormatString: Text): Text;
+    begin
+        exit(System.Format(Value, Length, FormatString));
+    end;
 }

--- a/app/src/Parser/Values/Value.Interface.al
+++ b/app/src/Parser/Values/Value.Interface.al
@@ -9,4 +9,9 @@ interface "Value FS"
 
     procedure GetProperty(Name: Text[120]): Interface "Value FS"
     procedure SetProperty(Name: Text[120]; NewValue: Interface "Value FS")
+
+    procedure Format(): Text
+    procedure Format(Length: Integer): Text
+    procedure Format(Length: Integer; FormatNumber: Integer): Text
+    procedure Format(Length: Integer; FormatString: Text): Text
 }

--- a/app/src/Parser/Values/VoidValue.Codeunit.al
+++ b/app/src/Parser/Values/VoidValue.Codeunit.al
@@ -33,4 +33,24 @@ codeunit 69100 "Void Value FS" implements "Value FS"
     begin
         Error('Void values do not support property access');
     end;
+
+    procedure Format(): Text;
+    begin
+        Error('Void values can not be formatted.');
+    end;
+
+    procedure Format(Length: Integer): Text;
+    begin
+        Error('Void values can not be formatted.');
+    end;
+
+    procedure Format(Length: Integer; FormatNumber: Integer): Text;
+    begin
+        Error('Void values can not be formatted.');
+    end;
+
+    procedure Format(Length: Integer; FormatString: Text): Text;
+    begin
+        Error('Void values can not be formatted.');
+    end;
 }


### PR DESCRIPTION
- n-arity functions - unified with methods
- use in `Message`, `Error`, `WriteLine`, `Format`
- add text substitution to `SetFilter`